### PR TITLE
[feat] 本番環境設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,17 @@
 version: '3.8'
 
 services:
+  nginx:
+    build:
+      context: ./nginx
+    ports:
+      - 80:80
+    networks:
+      - nestjs
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:cached
+    depends_on:
+      - server
   postgres:
     image: postgres:12
     environment:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:latest
+
+COPY ./default.conf /etc/nginx/conf.d/default.conf

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,12 @@
+server {
+    listen       80;
+    server_name  localhost;
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://server:3000/;
+    }
+}

--- a/server/ormconfig.ts
+++ b/server/ormconfig.ts
@@ -1,0 +1,19 @@
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+
+export const config: TypeOrmModuleOptions = {
+  type: 'postgres',
+  host: process.env.DATABASE_HOST,
+  port: 5432,
+  username: process.env.POSTGRES_USER,
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.DATABASE_SCHEMA,
+  entities: ['dist/src/**/*.entity{.ts,.js}'],
+  migrations: ['src/migrations/*.ts'],
+  cli: {
+    migrationsDir: 'src/migrations',
+  },
+  synchronize: false,
+  logging: true,
+};
+
+export default config;

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,12 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
+    "migration:create": "npm run build && npm run typeorm migration:create -- -n",
+    "migration:g": "npm run build && npm run typeorm migration:generate -- -n",
+    "migration:run": "npm run build && npm run typeorm migration:run",
+    "migration:revert": "npm run typeorm migration:revert"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",

--- a/server/src/config/configuration.ts
+++ b/server/src/config/configuration.ts
@@ -7,6 +7,6 @@ export default () => ({
     password: process.env.POSTGRES_PASSWORD,
     database: process.env.DATABASE_SHCEMA,
     entities: ['dist/**/**.entity{.ts,.js}'],
-    synchronize: true,
+    // synchronize: true,
   },
 });

--- a/server/src/migrations/1641791577624-createUser.ts
+++ b/server/src/migrations/1641791577624-createUser.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class createUser1641791577624 implements MigrationInterface {
+  name = 'createUser1641791577624';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "user" ("id" SERIAL NOT NULL, "firstName" character varying NOT NULL, "lastName" character varying NOT NULL, "isActive" boolean NOT NULL DEFAULT true, "created" TIMESTAMP NOT NULL DEFAULT now(), "updated" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "user"`);
+  }
+}


### PR DESCRIPTION
fix #5 

## 学んだこと
- ormconfig.tsがないと、typeormをCLIで実行出来ない
- ```docker-compose exec server npm run migration:g ~~~name``` にしないと、migration出来ない
  - docker内で処理するため、npm run migration~~~ だけだとhostがずれてしまうのでdocker execが必要
